### PR TITLE
Add Bumpfile required by wader/bump action

### DIFF
--- a/Bumpfile
+++ b/Bumpfile
@@ -1,0 +1,1 @@
+Dockerfile


### PR DESCRIPTION
## Summary

- Adds a `Bumpfile` listing `Dockerfile` as the file to scan for embedded `# bump:` annotations
- Without this file, the wader/bump action fails with `open Bumpfile: no such file or directory`

## Test plan

- [ ] Verify the bump workflow completes without the `open Bumpfile: no such file or directory` error
- [ ] Trigger workflow manually via `workflow_dispatch` to confirm it runs end-to-end

---
_Generated by [Claude Code](https://claude.ai/code/session_01SENwtQYAiB5xUdmFcyNW7s)_