### PR TITLE
Upgrade actions/checkout to v6.0.2 across all workflows

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish_to_dockerhub.yml
+++ b/.github/workflows/publish_to_dockerhub.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary
This PR updates the `actions/checkout` action to version 6.0.2 across all GitHub Actions workflows in the repository.

## Key Changes
- Updated `actions/checkout` from v4 to v6.0.2 in `.github/workflows/bump.yml`
- Updated `actions/checkout` from v4 to v6.0.2 in `.github/workflows/docker-image.yml`
- Updated `actions/checkout` from v3 to v6.0.2 in `.github/workflows/publish_to_dockerhub.yml`

## Details
All three workflows now use the same pinned version of `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2), ensuring consistency across the CI/CD pipeline and benefiting from the latest improvements and security updates in the checkout action.

https://claude.ai/code/session_01DpgLmdjCe8QbiZGTevBrT4