### PR TITLE
fix: use GitHub App token in bump workflow so created PRs trigger CI checks

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -15,15 +15,23 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Check out the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git credentials
-        run: git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Bump versions
         uses: wader/bump/action@771bb30f8fb13ad5867dacec5ccadd43b89e777e # master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -29,7 +29,9 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git credentials
-        run: git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: git config --global url."https://x-access-token:${APP_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Bump versions
         uses: wader/bump/action@771bb30f8fb13ad5867dacec5ccadd43b89e777e # master


### PR DESCRIPTION
PRs opened with GITHUB_TOKEN are blocked from triggering pull_request
workflows by GitHub's security model. Switching to a GitHub App token
causes the PR to be treated as a regular user action, which allows
docker-image.yml and zizmor.yml to run normally.

Requires APP_ID and APP_PRIVATE_KEY secrets to be configured in the repo.

https://claude.ai/code/session_01Hx8XS8MP7G4rEjARDmvLxB