### PR TITLE
fix: replace deprecated app-id with client-id in bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -19,7 +19,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Check out the repo


### PR DESCRIPTION
actions/create-github-app-token deprecated the app-id input in favour of client-id.

https://claude.ai/code/session_018LSPTFs8BFiQjoMNeUTYXv