### PR TITLE
Fix libwebp bump filter and theora download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -232,9 +232,9 @@ RUN echo "---- ogg ----" && \
 # bump: theora after ./hashupdate Dockerfile THEORA $LATEST
 # bump: theora link "Release notes" https://github.com/xiph/theora/releases/tag/v$LATEST
 # bump: theora link "Source diff $CURRENT..$LATEST" https://github.com/xiph/theora/compare/v$CURRENT..v$LATEST
-ARG THEORA_VERSION=1.1.1
+ARG THEORA_VERSION=1.2.0
 ARG THEORA_URL="https://github.com/xiph/theora/archive/v$THEORA_VERSION.tar.gz"
-ARG THEORA_SHA256=1d5c3b25bbced448f3e741c42df6796e3d5e57136a74bcd68262318290ec2982
+ARG THEORA_SHA256=e0c35771b425c32a052ffb358a2aed14219340ab850b48dc85b01939c0513a31
 RUN echo "---- theora ----" && \
     wget $WGET_OPTS -O libtheora.tar.gz "$THEORA_URL" && \
     echo "$THEORA_SHA256  libtheora.tar.gz" | sha256sum --status -c - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -241,7 +241,7 @@ RUN echo "---- theora ----" && \
     tar xf libtheora.tar.gz && \
     # --build=$(arch)-unknown-linux-gnu helps with guessing the correct build. For some reason,
     # build script can't guess the build type in arm64 (hardware and emulated) environment.
-    cd theora-* && ./configure --build=$(arch)-unknown-linux-gnu --disable-examples --disable-oggtest --disable-shared --enable-static && \
+    cd theora-* && ./autogen.sh && ./configure --build=$(arch)-unknown-linux-gnu --disable-examples --disable-oggtest --disable-shared --enable-static && \
     make -j$(nproc) install
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -233,15 +233,15 @@ RUN echo "---- ogg ----" && \
 # bump: theora link "Release notes" https://github.com/xiph/theora/releases/tag/v$LATEST
 # bump: theora link "Source diff $CURRENT..$LATEST" https://github.com/xiph/theora/compare/v$CURRENT..v$LATEST
 ARG THEORA_VERSION=1.1.1
-ARG THEORA_URL="https://downloads.xiph.org/releases/theora/libtheora-$THEORA_VERSION.tar.bz2"
-ARG THEORA_SHA256=b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc
+ARG THEORA_URL="https://github.com/xiph/theora/archive/v$THEORA_VERSION.tar.gz"
+ARG THEORA_SHA256=1d5c3b25bbced448f3e741c42df6796e3d5e57136a74bcd68262318290ec2982
 RUN echo "---- theora ----" && \
-    wget $WGET_OPTS -O libtheora.tar.bz2 "$THEORA_URL" && \
-    echo "$THEORA_SHA256  libtheora.tar.bz2" | sha256sum --status -c - && \
-    tar xf libtheora.tar.bz2 && \
+    wget $WGET_OPTS -O libtheora.tar.gz "$THEORA_URL" && \
+    echo "$THEORA_SHA256  libtheora.tar.gz" | sha256sum --status -c - && \
+    tar xf libtheora.tar.gz && \
     # --build=$(arch)-unknown-linux-gnu helps with guessing the correct build. For some reason,
     # build script can't guess the build type in arm64 (hardware and emulated) environment.
-    cd libtheora-* && ./configure --build=$(arch)-unknown-linux-gnu --disable-examples --disable-oggtest --disable-shared --enable-static && \
+    cd theora-* && ./configure --build=$(arch)-unknown-linux-gnu --disable-examples --disable-oggtest --disable-shared --enable-static && \
     make -j$(nproc) install
 
 
@@ -288,7 +288,7 @@ RUN echo "---- vorbis ----" && \
 #  make -j$(nproc) install
 
 
-# bump: libwebp /LIBWEBP_VERSION=([\d.]+)/ https://github.com/webmproject/libwebp.git|*
+# bump: libwebp /LIBWEBP_VERSION=([\d.]+)/ https://github.com/webmproject/libwebp.git|/^\d+\.\d+\.\d+$/
 # bump: libwebp after ./hashupdate Dockerfile LIBWEBP $LATEST
 # bump: libwebp link "Release notes" https://github.com/webmproject/libwebp/releases/tag/v$LATEST
 # bump: libwebp link "Source diff $CURRENT..$LATEST" https://github.com/webmproject/libwebp/compare/v$CURRENT..v$LATEST


### PR DESCRIPTION
libwebp: restrict bump filter from |* to |/^\d+\.\d+\.\d+$/ so the
webp-rfc9649 tag (marking RFC standardization) is not misread as
version "9649" and selected over the real 1.6.0 release.

theora: switch download URL from xiph.org (which has no 1.2.0 tarball)
to GitHub archives so future bumps resolve correctly. Update SHA256,
file extension, and cd glob (GitHub archives extract as theora-*, not
libtheora-*).

https://claude.ai/code/session_01XTi7jhhQhzxfAFpLYnwFZ7